### PR TITLE
chore: fix .env trailing line and ensure APP_ENV=local

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,4 @@ MONGO_DB=cdc_db
 MONGO_COLLECTION=cdc_events
 
 # App Settings
-APP_ENV=localexport $(cat .env
+APP_ENV=local


### PR DESCRIPTION
## Summary
Fixes minor .env formatting issue.

## Details
- Removed incomplete `export $(cat .env` line left from shell testing.
- Added missing `APP_ENV=local` for consistency.
- No functional or build impact.