### PR TITLE
Feature/streaming

### DIFF
--- a/src/integrationTest/java/com/streamforge/job/materialize/UserStateMaterializeIntegrationTest.java
+++ b/src/integrationTest/java/com/streamforge/job/materialize/UserStateMaterializeIntegrationTest.java
@@ -1,0 +1,201 @@
+package com.streamforge.job.materialize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.streamforge.core.BaseIntegrationTest;
+import com.streamforge.core.model.StreamEnvelop;
+import com.streamforge.core.util.JsonUtils;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.*;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@SuppressWarnings("resource")
+public class UserStateMaterializeIntegrationTest extends BaseIntegrationTest {
+
+  private static final String CHANGELOG_TOPIC = "user-changelog";
+  private static final List<StreamEnvelop> received = new CopyOnWriteArrayList<>();
+
+  @BeforeAll
+  static void startJob() throws Exception {
+    createKafkaTopic(CHANGELOG_TOPIC);
+
+    System.setProperty("STATE_TTL_HOURS", "1");
+    System.setProperty("CHANGELOG_TOPIC", CHANGELOG_TOPIC);
+
+    UserStateMaterializeJob job = new UserStateMaterializeJob();
+    StreamExecutionEnvironment env = job.buildPipeline();
+    Thread flinkThread =
+        new Thread(
+            () -> {
+              try {
+                env.execute();
+              } catch (Exception e) {
+                System.err.println("[ERROR] Flink execution failed: " + e.getMessage());
+              }
+            });
+    flinkThread.setDaemon(true);
+    flinkThread.start();
+
+    startChangelogConsumer();
+
+    Thread.sleep(3000);
+  }
+
+  private static void startChangelogConsumer() {
+    Thread consumer =
+        new Thread(
+            () -> {
+              try (var kafkaConsumer =
+                  new KafkaConsumer<String, String>(
+                      Map.of(
+                          "bootstrap.servers", kafka.getBootstrapServers(),
+                          "group.id", "test-changelog-consumer",
+                          "auto.offset.reset", "earliest",
+                          "key.deserializer",
+                              "org.apache.kafka.common.serialization.StringDeserializer",
+                          "value.deserializer",
+                              "org.apache.kafka.common.serialization.StringDeserializer"))) {
+                kafkaConsumer.subscribe(List.of(CHANGELOG_TOPIC));
+                while (!Thread.currentThread().isInterrupted()) {
+                  ConsumerRecords<String, String> records =
+                      kafkaConsumer.poll(Duration.ofMillis(500));
+                  records.forEach(
+                      r -> {
+                        StreamEnvelop envelop = JsonUtils.fromJson(r.value(), StreamEnvelop.class);
+                        received.add(envelop);
+                      });
+                }
+              }
+            });
+    consumer.setDaemon(true);
+    consumer.start();
+  }
+
+  @Test
+  @Order(1)
+  @DisplayName("should emit INSERT changelog to Kafka for new key")
+  void insertChangelog() throws Exception {
+    int before = received.size();
+    sendEvent("mat-user-1", "CREATE", "{\"name\":\"Alice\",\"age\":30}");
+
+    await()
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              List<StreamEnvelop> newEvents = received.subList(before, received.size());
+              assertThat(newEvents).anyMatch(e -> "CHANGELOG_INSERT".equals(e.getOperation()));
+
+              StreamEnvelop insert =
+                  newEvents.stream()
+                      .filter(e -> "CHANGELOG_INSERT".equals(e.getOperation()))
+                      .findFirst()
+                      .orElseThrow();
+              Map<String, Object> payload = insert.getPayloadAsMap();
+              assertThat(payload.get("changeType")).isEqualTo("INSERT");
+              assertThat(payload.get("after")).isNotNull();
+              assertThat(payload.get("before")).isNull();
+            });
+  }
+
+  @Test
+  @Order(2)
+  @DisplayName("should emit UPDATE changelog to Kafka for existing key")
+  void updateChangelog() throws Exception {
+    int before = received.size();
+    sendEvent("mat-user-1", "UPDATE", "{\"name\":\"Alice\",\"age\":31}");
+
+    await()
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              List<StreamEnvelop> newEvents = received.subList(before, received.size());
+              assertThat(newEvents).anyMatch(e -> "CHANGELOG_UPDATE".equals(e.getOperation()));
+
+              StreamEnvelop update =
+                  newEvents.stream()
+                      .filter(e -> "CHANGELOG_UPDATE".equals(e.getOperation()))
+                      .findFirst()
+                      .orElseThrow();
+              Map<String, Object> payload = update.getPayloadAsMap();
+              assertThat(payload.get("changeType")).isEqualTo("UPDATE");
+              assertThat(payload.get("before")).isNotNull();
+              assertThat(payload.get("after")).isNotNull();
+            });
+  }
+
+  @Test
+  @Order(3)
+  @DisplayName("should emit DELETE changelog to Kafka when delete predicate matches")
+  void deleteChangelog() throws Exception {
+    int before = received.size();
+    sendEvent("mat-user-1", "DELETE", "{\"name\":\"Alice\",\"age\":31}");
+
+    await()
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              List<StreamEnvelop> newEvents = received.subList(before, received.size());
+              assertThat(newEvents).anyMatch(e -> "CHANGELOG_DELETE".equals(e.getOperation()));
+
+              StreamEnvelop delete =
+                  newEvents.stream()
+                      .filter(e -> "CHANGELOG_DELETE".equals(e.getOperation()))
+                      .findFirst()
+                      .orElseThrow();
+              Map<String, Object> payload = delete.getPayloadAsMap();
+              assertThat(payload.get("changeType")).isEqualTo("DELETE");
+              assertThat(payload.get("before")).isNotNull();
+              assertThat(payload.get("after")).isNull();
+            });
+  }
+
+  @Test
+  @Order(4)
+  @DisplayName("should emit re-INSERT changelog after DELETE for same key")
+  void reInsertAfterDelete() throws Exception {
+    int before = received.size();
+    sendEvent("mat-user-1", "CREATE", "{\"name\":\"Bob\",\"age\":25}");
+
+    await()
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              List<StreamEnvelop> newEvents = received.subList(before, received.size());
+              assertThat(newEvents).anyMatch(e -> "CHANGELOG_INSERT".equals(e.getOperation()));
+            });
+  }
+
+  private void sendEvent(String userId, String operation, String payloadJson) throws Exception {
+    try (var producer =
+        new KafkaProducer<String, String>(
+            Map.of(
+                "bootstrap.servers", kafka.getBootstrapServers(),
+                "key.serializer", "org.apache.kafka.common.serialization.StringSerializer",
+                "value.serializer", "org.apache.kafka.common.serialization.StringSerializer"))) {
+      StreamEnvelop envelop =
+          StreamEnvelop.builder()
+              .operation(operation)
+              .source("user-service")
+              .payloadJson(payloadJson)
+              .primaryKey(userId)
+              .eventTime(Instant.now())
+              .processedTime(Instant.now())
+              .traceId(UUID.randomUUID().toString())
+              .build();
+      producer.send(new ProducerRecord<>(KAFKA_TOPIC_MAIN, envelop.toJson())).get();
+    }
+  }
+}

--- a/src/integrationTest/java/com/streamforge/job/session/UserSessionAnalysisIntegrationTest.java
+++ b/src/integrationTest/java/com/streamforge/job/session/UserSessionAnalysisIntegrationTest.java
@@ -1,0 +1,114 @@
+package com.streamforge.job.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.streamforge.core.BaseIntegrationTest;
+import com.streamforge.core.model.StreamEnvelop;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.bson.Document;
+import org.junit.jupiter.api.*;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@SuppressWarnings("resource")
+public class UserSessionAnalysisIntegrationTest extends BaseIntegrationTest {
+
+  @BeforeAll
+  static void startJob() throws Exception {
+    System.setProperty("SESSION_GAP_SECONDS", "5");
+
+    UserSessionAnalysisJob job = new UserSessionAnalysisJob();
+    StreamExecutionEnvironment env = job.buildPipeline();
+    Thread flinkThread =
+        new Thread(
+            () -> {
+              try {
+                env.execute();
+              } catch (Exception e) {
+                System.err.println("[ERROR] Flink execution failed: " + e.getMessage());
+              }
+            });
+    flinkThread.setDaemon(true);
+    flinkThread.start();
+
+    Thread.sleep(3000);
+  }
+
+  @Test
+  @Order(1)
+  @DisplayName("should produce session result in MongoDB after session closes")
+  void sessionClosedAndWrittenToMongo() throws Exception {
+    Instant base = Instant.now();
+
+    sendEvent("user-session-1", "CLICK", base);
+    sendEvent("user-session-1", "SCROLL", base.plusMillis(1000));
+    sendEvent("user-session-1", "BUY", base.plusMillis(2000));
+
+    Thread.sleep(1000);
+
+    sendEvent("trigger", "TRIGGER", base.plusMillis(60000));
+
+    await()
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              Document doc = waitForMongoDocument("user-session-1", 1, null);
+              assertThat(doc).isNotNull();
+              assertThat(doc.getString("actions")).isEqualTo("CLICK,SCROLL,BUY");
+              assertThat(doc.getInteger("count")).isEqualTo(3);
+            });
+  }
+
+  @Test
+  @Order(2)
+  @DisplayName("should produce separate sessions when gap exceeded")
+  void separateSessionsOnGap() throws Exception {
+    Instant base = Instant.now().plusMillis(100000);
+
+    sendEvent("user-session-2", "VIEW", base);
+    sendEvent("user-session-2", "CLICK", base.plusMillis(1000));
+
+    Thread.sleep(1000);
+
+    sendEvent("trigger2", "TRIGGER", base.plusMillis(60000));
+
+    await()
+        .atMost(Duration.ofSeconds(15))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              Document doc = waitForMongoDocument("user-session-2", 1, null);
+              assertThat(doc).isNotNull();
+              assertThat(doc.getString("actions")).isEqualTo("VIEW,CLICK");
+              assertThat(doc.getInteger("count")).isEqualTo(2);
+            });
+  }
+
+  private void sendEvent(String userId, String operation, Instant eventTime) throws Exception {
+    try (var producer =
+        new KafkaProducer<String, String>(
+            Map.of(
+                "bootstrap.servers", kafka.getBootstrapServers(),
+                "key.serializer", "org.apache.kafka.common.serialization.StringSerializer",
+                "value.serializer", "org.apache.kafka.common.serialization.StringSerializer"))) {
+      StreamEnvelop envelop =
+          StreamEnvelop.builder()
+              .operation(operation)
+              .source("clickstream")
+              .payloadJson("{}")
+              .primaryKey(userId)
+              .eventTime(eventTime)
+              .processedTime(Instant.now())
+              .traceId(UUID.randomUUID().toString())
+              .build();
+      producer.send(new ProducerRecord<>(KAFKA_TOPIC_MAIN, envelop.toJson())).get();
+    }
+  }
+}

--- a/src/main/java/com/streamforge/connector/mongo/MultiCdcSourceBuilder.java
+++ b/src/main/java/com/streamforge/connector/mongo/MultiCdcSourceBuilder.java
@@ -1,0 +1,43 @@
+package com.streamforge.connector.mongo;
+
+import static com.streamforge.core.config.ScopedConfig.getOrDefault;
+
+import com.streamforge.core.pipeline.PipelineBuilder;
+import java.io.Serial;
+import java.io.Serializable;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.bson.Document;
+
+public class MultiCdcSourceBuilder
+    implements PipelineBuilder.SourceBuilder<Document>, Serializable {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  public static final String CDC_PARALLELISM = "CDC_PARALLELISM";
+  private static final int DEFAULT_PARALLELISM = 4;
+
+  @Override
+  public DataStream<Document> build(StreamExecutionEnvironment env, String jobName) {
+    int numConnectors =
+        Integer.parseInt(getOrDefault(CDC_PARALLELISM, String.valueOf(DEFAULT_PARALLELISM)));
+    return build(env, jobName, numConnectors);
+  }
+
+  @SuppressWarnings("unchecked")
+  DataStream<Document> build(StreamExecutionEnvironment env, String jobName, int numConnectors) {
+    if (numConnectors <= 1) {
+      return new MongoChangeStreamSource().build(env, jobName);
+    }
+
+    MongoChangeStreamSource source = new MongoChangeStreamSource();
+    DataStream<Document> first = source.build(env, jobName, 0, numConnectors);
+
+    DataStream<Document>[] rest = new DataStream[numConnectors - 1];
+    for (int i = 1; i < numConnectors; i++) {
+      rest[i - 1] = source.build(env, jobName, i, numConnectors);
+    }
+
+    return first.union(rest);
+  }
+}

--- a/src/main/java/com/streamforge/core/config/MetricKeys.java
+++ b/src/main/java/com/streamforge/core/config/MetricKeys.java
@@ -68,6 +68,11 @@ public final class MetricKeys {
   public static final String MATERIALIZER_UPDATE_COUNT = "materializer.update_count";
   public static final String MATERIALIZER_DELETE_COUNT = "materializer.delete_count";
 
+  public static final String CDC_READ_COUNT = "cdc.read_count";
+  public static final String CDC_RECONNECT_COUNT = "cdc.reconnect_count";
+  public static final String CDC_CHECKPOINT_COUNT = "cdc.checkpoint_count";
+
   public static final String KAFKA = "kafka";
   public static final String MONGO = "mongo";
+  public static final String CDC = "cdc";
 }

--- a/src/main/java/com/streamforge/core/config/MetricKeys.java
+++ b/src/main/java/com/streamforge/core/config/MetricKeys.java
@@ -62,6 +62,8 @@ public final class MetricKeys {
   public static final String ASYNC_ENRICHER_TIMEOUT_COUNT = "async_enricher.timeout_count";
   public static final String ASYNC_ENRICHER_ERROR_COUNT = "async_enricher.error_count";
 
+  public static final String SESSION_CLOSED_COUNT = "session.closed_count";
+
   public static final String KAFKA = "kafka";
   public static final String MONGO = "mongo";
 }

--- a/src/main/java/com/streamforge/core/config/MetricKeys.java
+++ b/src/main/java/com/streamforge/core/config/MetricKeys.java
@@ -64,6 +64,10 @@ public final class MetricKeys {
 
   public static final String SESSION_CLOSED_COUNT = "session.closed_count";
 
+  public static final String MATERIALIZER_INSERT_COUNT = "materializer.insert_count";
+  public static final String MATERIALIZER_UPDATE_COUNT = "materializer.update_count";
+  public static final String MATERIALIZER_DELETE_COUNT = "materializer.delete_count";
+
   public static final String KAFKA = "kafka";
   public static final String MONGO = "mongo";
 }

--- a/src/main/java/com/streamforge/job/cdc/KafkaToMongoJob.java
+++ b/src/main/java/com/streamforge/job/cdc/KafkaToMongoJob.java
@@ -5,8 +5,8 @@ import com.streamforge.connector.mongo.MongoSinkBuilder;
 import com.streamforge.core.config.ScopedConfig;
 import com.streamforge.core.launcher.StreamJob;
 import com.streamforge.core.model.StreamEnvelop;
+import com.streamforge.core.parser.StreamEnvelopParser;
 import com.streamforge.core.pipeline.PipelineBuilder;
-import com.streamforge.job.cdc.parser.KafkaToMongoParser;
 import com.streamforge.job.cdc.processor.KafkaToMongoProcessor;
 import com.streamforge.pattern.enrich.StaticJoiner;
 import com.streamforge.pattern.quality.ConstraintEnforcer;
@@ -22,7 +22,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 public class KafkaToMongoJob implements StreamJob {
 
   public static final String JOB_NAME = "KafkaToMongo";
-  public static final String PARSER_NAME = "KafkaToMongoParser";
+  public static final String PARSER_NAME = "StreamEnvelopParser";
   public static final String PROCESSOR_NAME = "KafkaToMongoProcessor";
   public static final String REFERENCE_TOPIC = "REFERENCE_TOPIC";
   public static final String REFERENCE_TOPIC_2 = "REFERENCE_TOPIC_2";
@@ -41,7 +41,7 @@ public class KafkaToMongoJob implements StreamJob {
 
     var builder =
         PipelineBuilder.from(new KafkaSourceBuilder().build(env, name()))
-            .parse(new KafkaToMongoParser());
+            .parse(new StreamEnvelopParser(JOB_NAME));
 
     if (ref1 != null) {
       builder = builder.enrich(ref1, buildJoiner("ref-state-1", "enrichedRef1"));
@@ -66,7 +66,7 @@ public class KafkaToMongoJob implements StreamJob {
     String refTopic = ScopedConfig.require(topicKey);
     DataStream<String> refRaw =
         new KafkaSourceBuilder().build(env, name() + "-" + suffix, refTopic);
-    return new KafkaToMongoParser().parse(refRaw);
+    return new StreamEnvelopParser(JOB_NAME).parse(refRaw);
   }
 
   private StaticJoiner<StreamEnvelop, StreamEnvelop> buildJoiner(

--- a/src/main/java/com/streamforge/job/cdc/MongoToKafkaJob.java
+++ b/src/main/java/com/streamforge/job/cdc/MongoToKafkaJob.java
@@ -1,7 +1,7 @@
 package com.streamforge.job.cdc;
 
 import com.streamforge.connector.kafka.KafkaSinkBuilder;
-import com.streamforge.connector.mongo.MongoChangeStreamSource;
+import com.streamforge.connector.mongo.MultiCdcSourceBuilder;
 import com.streamforge.core.config.ScopedConfig;
 import com.streamforge.core.launcher.StreamJob;
 import com.streamforge.core.model.StreamEnvelop;
@@ -38,7 +38,7 @@ public class MongoToKafkaJob implements StreamJob {
   public StreamExecutionEnvironment buildPipeline(PipelineBuilder.SinkBuilder<StreamEnvelop> sink) {
     StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
     env.setParallelism(1);
-    PipelineBuilder.from(new MongoChangeStreamSource().build(env, name()))
+    PipelineBuilder.from(new MultiCdcSourceBuilder().build(env, name()))
         .parse(new MongoToKafkaParser())
         .apply(new FlowDisruptionDetector<>(StreamEnvelop::getSource, Duration.ofMinutes(5)))
         .apply(new FilterInterceptor<>(e -> !"unknown".equals(e.getOperation())))

--- a/src/main/java/com/streamforge/job/ingest/MergedIngestJob.java
+++ b/src/main/java/com/streamforge/job/ingest/MergedIngestJob.java
@@ -8,8 +8,8 @@ import com.streamforge.connector.mongo.MongoSinkBuilder;
 import com.streamforge.core.config.ScopedConfig;
 import com.streamforge.core.launcher.StreamJob;
 import com.streamforge.core.model.StreamEnvelop;
+import com.streamforge.core.parser.StreamEnvelopParser;
 import com.streamforge.core.pipeline.PipelineBuilder;
-import com.streamforge.job.cdc.parser.KafkaToMongoParser;
 import com.streamforge.pattern.split.OrderedFanIn;
 import java.time.Duration;
 import java.util.HashMap;
@@ -38,12 +38,12 @@ public class MergedIngestJob implements StreamJob {
 
     require(STREAM_TOPIC);
     DataStream<String> ordersRaw = new KafkaSourceBuilder().build(env, name());
-    DataStream<StreamEnvelop> orders = new KafkaToMongoParser().parse(ordersRaw);
+    DataStream<StreamEnvelop> orders = new StreamEnvelopParser(JOB_NAME).parse(ordersRaw);
 
     String secondaryTopic = require(STREAM_TOPIC_SECONDARY);
     DataStream<String> paymentsRaw =
         new KafkaSourceBuilder().build(env, name() + "-secondary", secondaryTopic);
-    DataStream<StreamEnvelop> payments = new KafkaToMongoParser().parse(paymentsRaw);
+    DataStream<StreamEnvelop> payments = new StreamEnvelopParser(JOB_NAME).parse(paymentsRaw);
 
     DataStream<StreamEnvelop> merged =
         OrderedFanIn.builder(StreamEnvelop::getEventTime)

--- a/src/main/java/com/streamforge/job/join/OrderPaymentJoinJob.java
+++ b/src/main/java/com/streamforge/job/join/OrderPaymentJoinJob.java
@@ -7,8 +7,8 @@ import com.streamforge.connector.mongo.MongoSinkBuilder;
 import com.streamforge.core.config.ScopedConfig;
 import com.streamforge.core.launcher.StreamJob;
 import com.streamforge.core.model.StreamEnvelop;
+import com.streamforge.core.parser.StreamEnvelopParser;
 import com.streamforge.core.pipeline.PipelineBuilder;
-import com.streamforge.job.cdc.parser.KafkaToMongoParser;
 import com.streamforge.pattern.enrich.DynamicJoiner;
 import java.time.Duration;
 import java.util.HashMap;
@@ -38,12 +38,12 @@ public class OrderPaymentJoinJob implements StreamJob {
 
     ScopedConfig.require(STREAM_TOPIC);
     DataStream<String> ordersRaw = new KafkaSourceBuilder().build(env, name());
-    DataStream<StreamEnvelop> orders = new KafkaToMongoParser().parse(ordersRaw);
+    DataStream<StreamEnvelop> orders = new StreamEnvelopParser(JOB_NAME).parse(ordersRaw);
 
     String paymentTopic = ScopedConfig.require(PAYMENT_TOPIC);
     DataStream<String> paymentsRaw =
         new KafkaSourceBuilder().build(env, name() + "-payments", paymentTopic);
-    DataStream<StreamEnvelop> payments = new KafkaToMongoParser().parse(paymentsRaw);
+    DataStream<StreamEnvelop> payments = new StreamEnvelopParser(JOB_NAME).parse(paymentsRaw);
 
     Duration ttl =
         Duration.ofMinutes(Long.parseLong(ScopedConfig.getOrDefault(JOIN_TTL_MINUTES, "10")));

--- a/src/main/java/com/streamforge/job/materialize/UserStateMaterializeJob.java
+++ b/src/main/java/com/streamforge/job/materialize/UserStateMaterializeJob.java
@@ -1,0 +1,115 @@
+package com.streamforge.job.materialize;
+
+import static com.streamforge.connector.kafka.KafkaConfigKeys.*;
+
+import com.streamforge.connector.kafka.KafkaSourceBuilder;
+import com.streamforge.core.config.ScopedConfig;
+import com.streamforge.core.launcher.StreamJob;
+import com.streamforge.core.model.StreamEnvelop;
+import com.streamforge.core.parser.StreamEnvelopParser;
+import com.streamforge.core.util.JsonUtils;
+import com.streamforge.pattern.materialization.ChangelogEvent;
+import com.streamforge.pattern.materialization.Materializer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+public class UserStateMaterializeJob implements StreamJob {
+
+  public static final String JOB_NAME = "UserStateMaterialize";
+  public static final String STATE_TTL_HOURS = "STATE_TTL_HOURS";
+  public static final String CHANGELOG_TOPIC = "CHANGELOG_TOPIC";
+
+  @Override
+  public String name() {
+    return JOB_NAME;
+  }
+
+  public StreamExecutionEnvironment buildPipeline() {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+
+    ScopedConfig.require(STREAM_TOPIC);
+    String changelogTopic = ScopedConfig.require(CHANGELOG_TOPIC);
+
+    DataStream<String> raw = new KafkaSourceBuilder().build(env, name());
+    DataStream<StreamEnvelop> events = new StreamEnvelopParser(JOB_NAME).parse(raw);
+
+    Duration ttl =
+        Duration.ofHours(Long.parseLong(ScopedConfig.getOrDefault(STATE_TTL_HOURS, "24")));
+
+    DataStream<ChangelogEvent<StreamEnvelop>> changelog = buildMaterializer(ttl).apply(events);
+    DataStream<StreamEnvelop> output = changelog.map(UserStateMaterializeJob::toEnvelop);
+
+    output.sinkTo(buildChangelogSink(changelogTopic)).name("ChangelogKafkaSink");
+
+    return env;
+  }
+
+  static Materializer<StreamEnvelop> buildMaterializer(Duration ttl) {
+    return Materializer.<StreamEnvelop>builder()
+        .keyExtractor(StreamEnvelop::getPrimaryKey)
+        .ttl(ttl)
+        .deletePredicate(e -> "DELETE".equalsIgnoreCase(e.getOperation()))
+        .build();
+  }
+
+  private KafkaSink<StreamEnvelop> buildChangelogSink(String topic) {
+    return KafkaSink.<StreamEnvelop>builder()
+        .setBootstrapServers(ScopedConfig.require(KAFKA_BOOTSTRAP_SERVERS))
+        .setRecordSerializer(
+            KafkaRecordSerializationSchema.<StreamEnvelop>builder()
+                .setTopic(topic)
+                .setValueSerializationSchema(envelop -> JsonUtils.toJson(envelop).getBytes())
+                .build())
+        .setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+        .build();
+  }
+
+  static StreamEnvelop toEnvelop(ChangelogEvent<StreamEnvelop> event) {
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("_id", event.key());
+    payload.put("changeType", event.type().name());
+
+    if (event.after() != null) {
+      payload.put("after", event.after().getPayloadAsMap());
+    }
+    if (event.before() != null) {
+      payload.put("before", event.before().getPayloadAsMap());
+    }
+
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("changeType", event.type().name());
+    metadata.put("materializedKey", event.key());
+
+    return StreamEnvelop.builder()
+        .operation("CHANGELOG_" + event.type().name())
+        .source("materializer")
+        .payloadJson(JsonUtils.toJson(payload))
+        .primaryKey("_id")
+        .eventTime(event.timestamp())
+        .processedTime(Instant.now())
+        .metadata(metadata)
+        .build();
+  }
+
+  @Override
+  public void run(String[] args) throws Exception {
+    ScopedConfig.activateJob(name());
+    try (StreamExecutionEnvironment env = buildPipeline()) {
+      JobExecutionResult result = env.execute(name());
+      System.out.println("Job duration: " + result.getNetRuntime());
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    new UserStateMaterializeJob().run(args);
+  }
+}

--- a/src/main/java/com/streamforge/job/route/EventRouterJob.java
+++ b/src/main/java/com/streamforge/job/route/EventRouterJob.java
@@ -6,7 +6,7 @@ import com.streamforge.connector.mongo.MongoSinkBuilder;
 import com.streamforge.core.config.ScopedConfig;
 import com.streamforge.core.launcher.StreamJob;
 import com.streamforge.core.model.StreamEnvelop;
-import com.streamforge.job.cdc.parser.KafkaToMongoParser;
+import com.streamforge.core.parser.StreamEnvelopParser;
 import com.streamforge.pattern.split.ParallelSplitter;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -27,7 +27,7 @@ public class EventRouterJob implements StreamJob {
     env.setParallelism(1);
 
     DataStream<String> source = new KafkaSourceBuilder().build(env, name());
-    DataStream<StreamEnvelop> parsed = new KafkaToMongoParser().parse(source);
+    DataStream<StreamEnvelop> parsed = new StreamEnvelopParser(JOB_NAME).parse(source);
 
     var splitter =
         ParallelSplitter.builder(TypeInformation.of(StreamEnvelop.class))

--- a/src/main/java/com/streamforge/job/session/UserSessionAnalysisJob.java
+++ b/src/main/java/com/streamforge/job/session/UserSessionAnalysisJob.java
@@ -7,9 +7,9 @@ import com.streamforge.connector.mongo.MongoSinkBuilder;
 import com.streamforge.core.config.ScopedConfig;
 import com.streamforge.core.launcher.StreamJob;
 import com.streamforge.core.model.StreamEnvelop;
+import com.streamforge.core.parser.StreamEnvelopParser;
 import com.streamforge.core.pipeline.PipelineBuilder;
 import com.streamforge.core.util.JsonUtils;
-import com.streamforge.job.cdc.parser.KafkaToMongoParser;
 import com.streamforge.pattern.session.SessionAnalyzer;
 import com.streamforge.pattern.session.SessionResult;
 import java.time.Duration;
@@ -42,7 +42,7 @@ public class UserSessionAnalysisJob implements StreamJob {
 
     ScopedConfig.require(STREAM_TOPIC);
     DataStream<String> raw = new KafkaSourceBuilder().build(env, name());
-    DataStream<StreamEnvelop> events = new KafkaToMongoParser().parse(raw);
+    DataStream<StreamEnvelop> events = new StreamEnvelopParser(JOB_NAME).parse(raw);
 
     Duration gap =
         Duration.ofSeconds(Long.parseLong(ScopedConfig.getOrDefault(SESSION_GAP_SECONDS, "1800")));

--- a/src/main/java/com/streamforge/job/session/UserSessionAnalysisJob.java
+++ b/src/main/java/com/streamforge/job/session/UserSessionAnalysisJob.java
@@ -1,0 +1,106 @@
+package com.streamforge.job.session;
+
+import static com.streamforge.connector.kafka.KafkaConfigKeys.*;
+
+import com.streamforge.connector.kafka.KafkaSourceBuilder;
+import com.streamforge.connector.mongo.MongoSinkBuilder;
+import com.streamforge.core.config.ScopedConfig;
+import com.streamforge.core.launcher.StreamJob;
+import com.streamforge.core.model.StreamEnvelop;
+import com.streamforge.core.pipeline.PipelineBuilder;
+import com.streamforge.core.util.JsonUtils;
+import com.streamforge.job.cdc.parser.KafkaToMongoParser;
+import com.streamforge.pattern.session.SessionAnalyzer;
+import com.streamforge.pattern.session.SessionResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+public class UserSessionAnalysisJob implements StreamJob {
+
+  public static final String JOB_NAME = "UserSessionAnalysis";
+  public static final String SESSION_GAP_SECONDS = "SESSION_GAP_SECONDS";
+
+  @Override
+  public String name() {
+    return JOB_NAME;
+  }
+
+  public StreamExecutionEnvironment buildPipeline() {
+    return buildPipeline(new MongoSinkBuilder());
+  }
+
+  public StreamExecutionEnvironment buildPipeline(
+      PipelineBuilder.SinkBuilder<StreamEnvelop> sinkBuilder) {
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+
+    ScopedConfig.require(STREAM_TOPIC);
+    DataStream<String> raw = new KafkaSourceBuilder().build(env, name());
+    DataStream<StreamEnvelop> events = new KafkaToMongoParser().parse(raw);
+
+    Duration gap =
+        Duration.ofSeconds(Long.parseLong(ScopedConfig.getOrDefault(SESSION_GAP_SECONDS, "1800")));
+
+    DataStream<SessionResult<String>> sessions = buildAnalyzer(gap).apply(events);
+    DataStream<StreamEnvelop> output = sessions.map(UserSessionAnalysisJob::toEnvelop);
+
+    sinkBuilder.write(output, name());
+
+    return env;
+  }
+
+  static SessionAnalyzer<StreamEnvelop, String> buildAnalyzer(Duration gap) {
+    return SessionAnalyzer.<StreamEnvelop, String>builder()
+        .keyExtractor(StreamEnvelop::getPrimaryKey)
+        .timestampExtractor(e -> e.getEventTime().toEpochMilli())
+        .aggregator(
+            events -> {
+              String actions =
+                  events.stream().map(StreamEnvelop::getOperation).collect(Collectors.joining(","));
+              return JsonUtils.toJson(Map.of("actions", actions, "count", events.size()));
+            })
+        .gap(gap)
+        .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  static StreamEnvelop toEnvelop(SessionResult<String> result) {
+    Map<String, Object> payload = JsonUtils.fromJson(result.result(), Map.class);
+    payload.put("_id", result.key());
+
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("sessionStart", result.sessionStart().toString());
+    metadata.put("sessionEnd", result.sessionEnd().toString());
+    metadata.put("eventCount", String.valueOf(result.eventCount()));
+    metadata.put("duration", result.duration().toString());
+
+    return StreamEnvelop.builder()
+        .operation("SESSION_CLOSED")
+        .source("session-analyzer")
+        .payloadJson(JsonUtils.toJson(payload))
+        .primaryKey("_id")
+        .eventTime(result.sessionStart())
+        .processedTime(Instant.now())
+        .metadata(metadata)
+        .build();
+  }
+
+  @Override
+  public void run(String[] args) throws Exception {
+    ScopedConfig.activateJob(name());
+    try (StreamExecutionEnvironment env = buildPipeline()) {
+      JobExecutionResult result = env.execute(name());
+      System.out.println("Job duration: " + result.getNetRuntime());
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    new UserSessionAnalysisJob().run(args);
+  }
+}

--- a/src/main/java/com/streamforge/pattern/materialization/ChangelogEvent.java
+++ b/src/main/java/com/streamforge/pattern/materialization/ChangelogEvent.java
@@ -1,0 +1,14 @@
+package com.streamforge.pattern.materialization;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public record ChangelogEvent<T>(ChangeType type, String key, T before, T after, Instant timestamp)
+    implements Serializable {
+
+  public enum ChangeType {
+    INSERT,
+    UPDATE,
+    DELETE
+  }
+}

--- a/src/main/java/com/streamforge/pattern/materialization/Materializer.java
+++ b/src/main/java/com/streamforge/pattern/materialization/Materializer.java
@@ -1,0 +1,166 @@
+package com.streamforge.pattern.materialization;
+
+import com.streamforge.core.config.MetricKeys;
+import com.streamforge.core.metric.Metrics;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.Predicate;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.util.Collector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Materializer<T> {
+
+  @FunctionalInterface
+  public interface KeyExtractor<T> extends Serializable {
+    String extract(T value);
+  }
+
+  @FunctionalInterface
+  public interface MergeFunction<T> extends Serializable {
+    T merge(T existing, T incoming);
+  }
+
+  public interface DeletePredicate<T> extends Predicate<T>, Serializable {}
+
+  private final KeyExtractor<T> keyExtractor;
+  private final Duration ttl;
+  private final MergeFunction<T> mergeFunction;
+  private final DeletePredicate<T> deletePredicate;
+
+  private Materializer(
+      KeyExtractor<T> keyExtractor,
+      Duration ttl,
+      MergeFunction<T> mergeFunction,
+      DeletePredicate<T> deletePredicate) {
+    this.keyExtractor = keyExtractor;
+    this.ttl = ttl;
+    this.mergeFunction = mergeFunction;
+    this.deletePredicate = deletePredicate;
+  }
+
+  public static <T> Builder<T> builder() {
+    return new Builder<>();
+  }
+
+  public DataStream<ChangelogEvent<T>> apply(DataStream<T> stream) {
+    return stream
+        .keyBy(keyExtractor::extract)
+        .process(new MaterializeFunction<>(ttl, mergeFunction, deletePredicate))
+        .name("Materializer");
+  }
+
+  public static final class Builder<T> {
+
+    private KeyExtractor<T> keyExtractor;
+    private Duration ttl;
+    private MergeFunction<T> mergeFunction;
+    private DeletePredicate<T> deletePredicate;
+
+    private Builder() {}
+
+    public Builder<T> keyExtractor(KeyExtractor<T> keyExtractor) {
+      this.keyExtractor = keyExtractor;
+      return this;
+    }
+
+    public Builder<T> ttl(Duration ttl) {
+      this.ttl = ttl;
+      return this;
+    }
+
+    public Builder<T> mergeFunction(MergeFunction<T> mergeFunction) {
+      this.mergeFunction = mergeFunction;
+      return this;
+    }
+
+    public Builder<T> deletePredicate(DeletePredicate<T> deletePredicate) {
+      this.deletePredicate = deletePredicate;
+      return this;
+    }
+
+    public Materializer<T> build() {
+      if (keyExtractor == null) {
+        throw new IllegalArgumentException("keyExtractor must not be null");
+      }
+      if (ttl == null) {
+        throw new IllegalArgumentException("ttl must not be null");
+      }
+      if (mergeFunction == null) {
+        mergeFunction = (existing, incoming) -> incoming;
+      }
+      return new Materializer<>(keyExtractor, ttl, mergeFunction, deletePredicate);
+    }
+  }
+
+  static class MaterializeFunction<T> extends KeyedProcessFunction<String, T, ChangelogEvent<T>> {
+
+    private static final Logger log = LoggerFactory.getLogger(Materializer.class);
+
+    private final Duration ttl;
+    private final MergeFunction<T> mergeFunction;
+    private final DeletePredicate<T> deletePredicate;
+    private transient ValueState<T> state;
+    private transient Metrics metrics;
+
+    MaterializeFunction(
+        Duration ttl, MergeFunction<T> mergeFunction, DeletePredicate<T> deletePredicate) {
+      this.ttl = ttl;
+      this.mergeFunction = mergeFunction;
+      this.deletePredicate = deletePredicate;
+    }
+
+    @Override
+    public void open(Configuration parameters) {
+      StateTtlConfig ttlConfig = StateTtlConfig.newBuilder(ttl).build();
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      ValueStateDescriptor<T> desc =
+          (ValueStateDescriptor<T>) new ValueStateDescriptor("materialized", Object.class);
+      desc.enableTimeToLive(ttlConfig);
+      this.state = getRuntimeContext().getState(desc);
+      this.metrics = new Metrics(getRuntimeContext(), "materializer", "Materializer");
+    }
+
+    @Override
+    public void processElement(T value, Context ctx, Collector<ChangelogEvent<T>> out)
+        throws Exception {
+      String key = ctx.getCurrentKey();
+      Instant timestamp = Instant.ofEpochMilli(ctx.timestamp() != null ? ctx.timestamp() : 0L);
+
+      if (deletePredicate != null && deletePredicate.test(value)) {
+        T before = state.value();
+        state.clear();
+        metrics.inc(MetricKeys.MATERIALIZER_DELETE_COUNT);
+        log.debug("[Materializer] DELETE for key: {}", key);
+        out.collect(
+            new ChangelogEvent<>(ChangelogEvent.ChangeType.DELETE, key, before, null, timestamp));
+        return;
+      }
+
+      T existing = state.value();
+
+      if (existing == null) {
+        state.update(value);
+        metrics.inc(MetricKeys.MATERIALIZER_INSERT_COUNT);
+        log.debug("[Materializer] INSERT for key: {}", key);
+        out.collect(
+            new ChangelogEvent<>(ChangelogEvent.ChangeType.INSERT, key, null, value, timestamp));
+      } else {
+        T merged = mergeFunction.merge(existing, value);
+        state.update(merged);
+        metrics.inc(MetricKeys.MATERIALIZER_UPDATE_COUNT);
+        log.debug("[Materializer] UPDATE for key: {}", key);
+        out.collect(
+            new ChangelogEvent<>(
+                ChangelogEvent.ChangeType.UPDATE, key, existing, merged, timestamp));
+      }
+    }
+  }
+}

--- a/src/main/java/com/streamforge/pattern/session/SessionAnalyzer.java
+++ b/src/main/java/com/streamforge/pattern/session/SessionAnalyzer.java
@@ -1,0 +1,187 @@
+package com.streamforge.pattern.session;
+
+import com.streamforge.core.config.MetricKeys;
+import com.streamforge.core.metric.Metrics;
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.WindowedStream;
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.EventTimeSessionWindows;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+public class SessionAnalyzer<T, R> {
+
+  @FunctionalInterface
+  public interface KeyExtractor<T> extends Serializable {
+    String extract(T value);
+  }
+
+  @FunctionalInterface
+  public interface TimestampExtractor<T> extends Serializable {
+    long extractMillis(T value);
+  }
+
+  @FunctionalInterface
+  public interface Aggregator<T, R> extends Serializable {
+    R aggregate(List<T> events);
+  }
+
+  private final KeyExtractor<T> keyExtractor;
+  private final TimestampExtractor<T> timestampExtractor;
+  private final Aggregator<T, R> aggregator;
+  private final Duration gap;
+  private final Duration allowedLateness;
+  private final Duration outOfOrderness;
+
+  private SessionAnalyzer(
+      KeyExtractor<T> keyExtractor,
+      TimestampExtractor<T> timestampExtractor,
+      Aggregator<T, R> aggregator,
+      Duration gap,
+      Duration allowedLateness,
+      Duration outOfOrderness) {
+    this.keyExtractor = keyExtractor;
+    this.timestampExtractor = timestampExtractor;
+    this.aggregator = aggregator;
+    this.gap = gap;
+    this.allowedLateness = allowedLateness;
+    this.outOfOrderness = outOfOrderness;
+  }
+
+  public static <T, R> Builder<T, R> builder() {
+    return new Builder<>();
+  }
+
+  public DataStream<SessionResult<R>> apply(DataStream<T> stream) {
+    TimestampExtractor<T> tsExtractor = this.timestampExtractor;
+
+    var withWatermarks =
+        stream.assignTimestampsAndWatermarks(
+            WatermarkStrategy.<T>forBoundedOutOfOrderness(outOfOrderness)
+                .withTimestampAssigner(
+                    (SerializableTimestampAssigner<T>)
+                        (element, recordTimestamp) -> tsExtractor.extractMillis(element)));
+
+    WindowedStream<T, String, TimeWindow> windowed =
+        withWatermarks.keyBy(keyExtractor::extract).window(EventTimeSessionWindows.withGap(gap));
+
+    if (allowedLateness != null) {
+      windowed = windowed.allowedLateness(allowedLateness);
+    }
+
+    return windowed.process(new SessionProcessFunction<>(aggregator)).name("SessionAnalyzer");
+  }
+
+  public static final class Builder<T, R> {
+
+    private KeyExtractor<T> keyExtractor;
+    private TimestampExtractor<T> timestampExtractor;
+    private Aggregator<T, R> aggregator;
+    private Duration gap;
+    private Duration allowedLateness;
+    private Duration outOfOrderness = Duration.ZERO;
+
+    private Builder() {}
+
+    public Builder<T, R> keyExtractor(KeyExtractor<T> keyExtractor) {
+      this.keyExtractor = keyExtractor;
+      return this;
+    }
+
+    public Builder<T, R> timestampExtractor(TimestampExtractor<T> timestampExtractor) {
+      this.timestampExtractor = timestampExtractor;
+      return this;
+    }
+
+    public Builder<T, R> aggregator(Aggregator<T, R> aggregator) {
+      this.aggregator = aggregator;
+      return this;
+    }
+
+    public Builder<T, R> gap(Duration gap) {
+      this.gap = gap;
+      return this;
+    }
+
+    public Builder<T, R> allowedLateness(Duration allowedLateness) {
+      this.allowedLateness = allowedLateness;
+      return this;
+    }
+
+    public Builder<T, R> outOfOrderness(Duration outOfOrderness) {
+      this.outOfOrderness = outOfOrderness;
+      return this;
+    }
+
+    public SessionAnalyzer<T, R> build() {
+      if (keyExtractor == null) {
+        throw new IllegalArgumentException("keyExtractor must not be null");
+      }
+      if (timestampExtractor == null) {
+        throw new IllegalArgumentException("timestampExtractor must not be null");
+      }
+      if (aggregator == null) {
+        throw new IllegalArgumentException("aggregator must not be null");
+      }
+      if (gap == null) {
+        throw new IllegalArgumentException("gap must not be null");
+      }
+      if (outOfOrderness == null) {
+        throw new IllegalArgumentException("outOfOrderness must not be null");
+      }
+      return new SessionAnalyzer<>(
+          keyExtractor, timestampExtractor, aggregator, gap, allowedLateness, outOfOrderness);
+    }
+  }
+
+  static class SessionProcessFunction<T, R>
+      extends ProcessWindowFunction<T, SessionResult<R>, String, TimeWindow> {
+
+    private final Aggregator<T, R> aggregator;
+    private transient Metrics metrics;
+
+    SessionProcessFunction(Aggregator<T, R> aggregator) {
+      this.aggregator = aggregator;
+    }
+
+    @Override
+    public void open(Configuration parameters) {
+      this.metrics = new Metrics(getRuntimeContext(), "session_analyzer", "SessionAnalyzer");
+    }
+
+    @Override
+    public void process(
+        String key,
+        ProcessWindowFunction<T, SessionResult<R>, String, TimeWindow>.Context context,
+        Iterable<T> elements,
+        Collector<SessionResult<R>> out) {
+
+      List<T> events = new ArrayList<>();
+      for (T event : elements) {
+        events.add(event);
+      }
+
+      TimeWindow window = context.window();
+      R result = aggregator.aggregate(events);
+
+      metrics.inc(MetricKeys.SESSION_CLOSED_COUNT);
+
+      out.collect(
+          new SessionResult<>(
+              key,
+              Instant.ofEpochMilli(window.getStart()),
+              Instant.ofEpochMilli(window.getEnd()),
+              events.size(),
+              Duration.ofMillis(window.getEnd() - window.getStart()),
+              result));
+    }
+  }
+}

--- a/src/main/java/com/streamforge/pattern/session/SessionResult.java
+++ b/src/main/java/com/streamforge/pattern/session/SessionResult.java
@@ -1,0 +1,14 @@
+package com.streamforge.pattern.session;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+
+public record SessionResult<R>(
+    String key,
+    Instant sessionStart,
+    Instant sessionEnd,
+    int eventCount,
+    Duration duration,
+    R result)
+    implements Serializable {}

--- a/src/main/resources/META-INF/services/com.streamforge.core.launcher.StreamJob
+++ b/src/main/resources/META-INF/services/com.streamforge.core.launcher.StreamJob
@@ -3,3 +3,4 @@ com.streamforge.job.cdc.KafkaToMongoJob
 com.streamforge.job.route.EventRouterJob
 com.streamforge.job.ingest.MergedIngestJob
 com.streamforge.job.join.OrderPaymentJoinJob
+com.streamforge.job.session.UserSessionAnalysisJob

--- a/src/test/java/com/streamforge/connector/mongo/MultiCdcSourceTest.java
+++ b/src/test/java/com/streamforge/connector/mongo/MultiCdcSourceTest.java
@@ -1,0 +1,83 @@
+package com.streamforge.connector.mongo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MultiCdcSourceTest {
+
+  @Nested
+  class HashModPipelineTest {
+
+    @Test
+    void singleSplitReturnsEmptyPipeline() {
+      List<Bson> pipeline = MongoChangeStreamSource.buildHashModPipeline(0, 1);
+      assertThat(pipeline).isEmpty();
+    }
+
+    @Test
+    void multipleSplitsReturnsMatchStage() {
+      List<Bson> pipeline = MongoChangeStreamSource.buildHashModPipeline(2, 4);
+      assertThat(pipeline).hasSize(1);
+
+      Document match = (Document) pipeline.get(0);
+      assertThat(match.containsKey("$match")).isTrue();
+
+      // verify the nested structure: $match.$expr.$eq[1] == splitIndex
+      Document expr = match.get("$match", Document.class).get("$expr", Document.class);
+      @SuppressWarnings("unchecked")
+      List<Object> eq = (List<Object>) expr.get("$eq");
+      assertThat(eq.get(1)).isEqualTo(2);
+
+      // verify $mod contains numSplits
+      @SuppressWarnings("unchecked")
+      List<Object> mod = ((Document) eq.get(0)).get("$mod", List.class);
+      assertThat(mod.get(1)).isEqualTo(4);
+    }
+
+    @Test
+    void differentSplitIndicesProduceDifferentFilters() {
+      List<Bson> pipeline0 = MongoChangeStreamSource.buildHashModPipeline(0, 3);
+      List<Bson> pipeline1 = MongoChangeStreamSource.buildHashModPipeline(1, 3);
+      List<Bson> pipeline2 = MongoChangeStreamSource.buildHashModPipeline(2, 3);
+
+      // each pipeline should have a different splitIndex in $eq
+      assertThat(extractSplitIndex(pipeline0)).isEqualTo(0);
+      assertThat(extractSplitIndex(pipeline1)).isEqualTo(1);
+      assertThat(extractSplitIndex(pipeline2)).isEqualTo(2);
+    }
+
+    @SuppressWarnings("unchecked")
+    private int extractSplitIndex(List<Bson> pipeline) {
+      Document match = (Document) pipeline.get(0);
+      Document expr = match.get("$match", Document.class).get("$expr", Document.class);
+      List<Object> eq = (List<Object>) expr.get("$eq");
+      return (int) eq.get(1);
+    }
+  }
+
+  @Nested
+  class MongoChangeStreamFlinkTest {
+
+    @Test
+    void defaultConstructorUsesNoFilter() {
+      MongoChangeStreamSource.MongoChangeStreamFlink flink =
+          new MongoChangeStreamSource.MongoChangeStreamFlink();
+      // should not throw — verifies construction with default (0, 1)
+      assertThat(flink.getBoundedness())
+          .isEqualTo(org.apache.flink.api.connector.source.Boundedness.CONTINUOUS_UNBOUNDED);
+    }
+
+    @Test
+    void parameterizedConstructorAcceptsSplitConfig() {
+      MongoChangeStreamSource.MongoChangeStreamFlink flink =
+          new MongoChangeStreamSource.MongoChangeStreamFlink(3, 8);
+      assertThat(flink.getBoundedness())
+          .isEqualTo(org.apache.flink.api.connector.source.Boundedness.CONTINUOUS_UNBOUNDED);
+    }
+  }
+}

--- a/src/test/java/com/streamforge/core/parser/StreamEnvelopParserTest.java
+++ b/src/test/java/com/streamforge/core/parser/StreamEnvelopParserTest.java
@@ -1,4 +1,4 @@
-package com.streamforge.job.cdc.parser;
+package com.streamforge.core.parser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -10,7 +10,7 @@ import com.streamforge.core.model.StreamEnvelop;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-class KafkaToMongoParserTest {
+class StreamEnvelopParserTest {
 
   @Test
   void testParse_validJson_shouldReturnStreamEnvelop() throws Exception {
@@ -23,7 +23,7 @@ class KafkaToMongoParserTest {
             .writeValueAsString(envelop);
 
     // when
-    StreamEnvelop result = KafkaToMongoParser.parseJson(json);
+    StreamEnvelop result = StreamEnvelopParser.parseJson(json);
 
     // then
     assertThat(result).isNotNull();
@@ -37,7 +37,7 @@ class KafkaToMongoParserTest {
     // given
     String invalidJson = "{invalid-json}";
 
-    assertThatThrownBy(() -> KafkaToMongoParser.parseJson(invalidJson))
+    assertThatThrownBy(() -> StreamEnvelopParser.parseJson(invalidJson))
         .isInstanceOf(Exception.class)
         .hasMessageContaining("Unexpected character");
   }

--- a/src/test/java/com/streamforge/job/session/UserSessionAnalysisJobTest.java
+++ b/src/test/java/com/streamforge/job/session/UserSessionAnalysisJobTest.java
@@ -1,0 +1,182 @@
+package com.streamforge.job.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.streamforge.core.model.StreamEnvelop;
+import com.streamforge.pattern.session.SessionAnalyzer;
+import com.streamforge.pattern.session.SessionResult;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class UserSessionAnalysisJobTest {
+
+  private static StreamEnvelop event(String userId, String operation, long epochMilli) {
+    return StreamEnvelop.builder()
+        .operation(operation)
+        .source("clickstream")
+        .payloadJson("{}")
+        .primaryKey(userId)
+        .eventTime(Instant.ofEpochMilli(epochMilli))
+        .processedTime(Instant.now())
+        .metadata(new HashMap<>())
+        .build();
+  }
+
+  private static <R> List<SessionResult<R>> execute(DataStream<SessionResult<R>> stream)
+      throws Exception {
+    List<SessionResult<R>> results = new ArrayList<>();
+    try (CloseableIterator<SessionResult<R>> iter = stream.executeAndCollect("test")) {
+      while (iter.hasNext()) {
+        results.add(iter.next());
+      }
+    }
+    return results;
+  }
+
+  @Nested
+  @DisplayName("Session analysis pipeline")
+  class SessionAnalysisPipeline {
+
+    @Test
+    @DisplayName("should detect single user session")
+    void singleUserSession() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      List<StreamEnvelop> data =
+          List.of(
+              event("user-1", "CLICK", 1000),
+              event("user-1", "SCROLL", 2000),
+              event("user-1", "CLICK", 3000));
+
+      DataStream<StreamEnvelop> source =
+          env.fromCollection(data, TypeInformation.of(StreamEnvelop.class));
+
+      SessionAnalyzer<StreamEnvelop, String> analyzer =
+          UserSessionAnalysisJob.buildAnalyzer(Duration.ofSeconds(5));
+
+      List<SessionResult<String>> results = execute(analyzer.apply(source));
+
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).key()).isEqualTo("user-1");
+      assertThat(results.get(0).eventCount()).isEqualTo(3);
+      assertThat(results.get(0).result()).contains("CLICK");
+      assertThat(results.get(0).result()).contains("SCROLL");
+    }
+
+    @Test
+    @DisplayName("should detect multiple sessions for same user")
+    void multipleSessionsSameUser() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      List<StreamEnvelop> data =
+          List.of(
+              event("user-1", "CLICK", 1000),
+              event("user-1", "SCROLL", 2000),
+              event("user-1", "CLICK", 20000),
+              event("user-1", "BUY", 21000));
+
+      DataStream<StreamEnvelop> source =
+          env.fromCollection(data, TypeInformation.of(StreamEnvelop.class));
+
+      SessionAnalyzer<StreamEnvelop, String> analyzer =
+          UserSessionAnalysisJob.buildAnalyzer(Duration.ofSeconds(5));
+
+      List<SessionResult<String>> results = execute(analyzer.apply(source));
+      results.sort(Comparator.comparing(SessionResult::sessionStart));
+
+      assertThat(results).hasSize(2);
+      assertThat(results.get(0).eventCount()).isEqualTo(2);
+      assertThat(results.get(1).eventCount()).isEqualTo(2);
+      assertThat(results.get(1).result()).contains("BUY");
+    }
+
+    @Test
+    @DisplayName("should handle multiple users independently")
+    void multipleUsers() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      List<StreamEnvelop> data =
+          List.of(
+              event("user-1", "CLICK", 1000),
+              event("user-2", "SCROLL", 1500),
+              event("user-1", "BUY", 2000),
+              event("user-2", "CLICK", 2500));
+
+      DataStream<StreamEnvelop> source =
+          env.fromCollection(data, TypeInformation.of(StreamEnvelop.class));
+
+      SessionAnalyzer<StreamEnvelop, String> analyzer =
+          UserSessionAnalysisJob.buildAnalyzer(Duration.ofSeconds(5));
+
+      List<SessionResult<String>> results = execute(analyzer.apply(source));
+
+      assertThat(results).hasSize(2);
+      assertThat(results.stream().map(SessionResult::key).collect(Collectors.toSet()))
+          .containsExactlyInAnyOrder("user-1", "user-2");
+      assertThat(results).allMatch(r -> r.eventCount() == 2);
+    }
+
+    @Test
+    @DisplayName("should aggregate actions in session result")
+    void aggregateActions() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      List<StreamEnvelop> data =
+          List.of(
+              event("user-1", "VIEW", 1000),
+              event("user-1", "ADD_CART", 2000),
+              event("user-1", "CHECKOUT", 3000));
+
+      DataStream<StreamEnvelop> source =
+          env.fromCollection(data, TypeInformation.of(StreamEnvelop.class));
+
+      SessionAnalyzer<StreamEnvelop, String> analyzer =
+          UserSessionAnalysisJob.buildAnalyzer(Duration.ofSeconds(5));
+
+      List<SessionResult<String>> results = execute(analyzer.apply(source));
+
+      assertThat(results).hasSize(1);
+      String result = results.get(0).result();
+      assertThat(result).contains("VIEW");
+      assertThat(result).contains("ADD_CART");
+      assertThat(result).contains("CHECKOUT");
+      assertThat(result).contains("\"count\":3");
+    }
+  }
+
+  @Nested
+  @DisplayName("SPI registration")
+  class SpiRegistration {
+
+    @Test
+    @DisplayName("should be discoverable via ServiceLoader")
+    void shouldBeDiscoverableViaSpi() {
+      var jobs = java.util.ServiceLoader.load(com.streamforge.core.launcher.StreamJob.class);
+      boolean found = false;
+      for (var job : jobs) {
+        if (job instanceof UserSessionAnalysisJob) {
+          found = true;
+          assertThat(job.name()).isEqualTo("UserSessionAnalysis");
+          break;
+        }
+      }
+      assertThat(found).isTrue();
+    }
+  }
+}

--- a/src/test/java/com/streamforge/pattern/materialization/MaterializerTest.java
+++ b/src/test/java/com/streamforge/pattern/materialization/MaterializerTest.java
@@ -1,0 +1,228 @@
+package com.streamforge.pattern.materialization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.List;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MaterializerTest {
+
+  private static final Duration TTL = Duration.ofMinutes(10);
+
+  @Nested
+  @DisplayName("INSERT")
+  class Insert {
+
+    @Test
+    @DisplayName("should emit INSERT for new key")
+    void insertForNewKey() throws Exception {
+      var operator =
+          new KeyedProcessOperator<>(
+              new Materializer.MaterializeFunction<String>(TTL, (a, b) -> b, null));
+
+      try (var harness =
+          new KeyedOneInputStreamOperatorTestHarness<>(operator, v -> v, Types.STRING)) {
+        harness.open();
+
+        harness.processElement(new StreamRecord<>("hello", 100L));
+
+        List<ChangelogEvent<String>> output = extractOutput(harness);
+
+        assertThat(output).hasSize(1);
+        assertThat(output.get(0).type()).isEqualTo(ChangelogEvent.ChangeType.INSERT);
+        assertThat(output.get(0).key()).isEqualTo("hello");
+        assertThat(output.get(0).before()).isNull();
+        assertThat(output.get(0).after()).isEqualTo("hello");
+      }
+    }
+
+    @Test
+    @DisplayName("should emit INSERT for each distinct key")
+    void insertForDistinctKeys() throws Exception {
+      var operator =
+          new KeyedProcessOperator<>(
+              new Materializer.MaterializeFunction<String>(TTL, (a, b) -> b, null));
+
+      try (var harness =
+          new KeyedOneInputStreamOperatorTestHarness<>(operator, v -> v, Types.STRING)) {
+        harness.open();
+
+        harness.processElement(new StreamRecord<>("a", 1L));
+        harness.processElement(new StreamRecord<>("b", 2L));
+        harness.processElement(new StreamRecord<>("c", 3L));
+
+        List<ChangelogEvent<String>> output = extractOutput(harness);
+
+        assertThat(output).hasSize(3);
+        assertThat(output).allMatch(e -> e.type() == ChangelogEvent.ChangeType.INSERT);
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("UPDATE")
+  class Update {
+
+    @Test
+    @DisplayName("should emit UPDATE with before/after for existing key")
+    void updateForExistingKey() throws Exception {
+      var operator =
+          new KeyedProcessOperator<>(
+              new Materializer.MaterializeFunction<String>(TTL, (a, b) -> b, null));
+
+      try (var harness =
+          new KeyedOneInputStreamOperatorTestHarness<>(
+              operator, v -> v.substring(0, 1), Types.STRING)) {
+        harness.open();
+
+        harness.processElement(new StreamRecord<>("v1", 1L));
+        harness.processElement(new StreamRecord<>("v2", 2L));
+
+        List<ChangelogEvent<String>> output = extractOutput(harness);
+
+        assertThat(output).hasSize(2);
+
+        ChangelogEvent<String> update = output.get(1);
+        assertThat(update.type()).isEqualTo(ChangelogEvent.ChangeType.UPDATE);
+        assertThat(update.before()).isEqualTo("v1");
+        assertThat(update.after()).isEqualTo("v2");
+      }
+    }
+
+    @Test
+    @DisplayName("should apply custom merge function on update")
+    void customMergeFunction() throws Exception {
+      Materializer.MergeFunction<String> concat = (existing, incoming) -> existing + "+" + incoming;
+
+      var operator =
+          new KeyedProcessOperator<>(new Materializer.MaterializeFunction<>(TTL, concat, null));
+
+      try (var harness =
+          new KeyedOneInputStreamOperatorTestHarness<>(
+              operator, v -> v.substring(0, 1), Types.STRING)) {
+        harness.open();
+
+        harness.processElement(new StreamRecord<>("a1", 1L));
+        harness.processElement(new StreamRecord<>("a2", 2L));
+
+        List<ChangelogEvent<String>> output = extractOutput(harness);
+
+        assertThat(output).hasSize(2);
+
+        ChangelogEvent<String> update = output.get(1);
+        assertThat(update.type()).isEqualTo(ChangelogEvent.ChangeType.UPDATE);
+        assertThat(update.before()).isEqualTo("a1");
+        assertThat(update.after()).isEqualTo("a1+a2");
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE")
+  class Delete {
+
+    @Test
+    @DisplayName("should emit DELETE when predicate matches")
+    void deleteWhenPredicateMatches() throws Exception {
+      Materializer.DeletePredicate<String> isDelete = v -> v.startsWith("DEL:");
+
+      var operator =
+          new KeyedProcessOperator<>(
+              new Materializer.MaterializeFunction<>(TTL, (a, b) -> b, isDelete));
+
+      try (var harness =
+          new KeyedOneInputStreamOperatorTestHarness<>(
+              operator, v -> v.startsWith("DEL:") ? v.substring(4) : v, Types.STRING)) {
+        harness.open();
+
+        harness.processElement(new StreamRecord<>("hello", 1L));
+        harness.processElement(new StreamRecord<>("DEL:hello", 2L));
+
+        List<ChangelogEvent<String>> output = extractOutput(harness);
+
+        assertThat(output).hasSize(2);
+
+        ChangelogEvent<String> insert = output.get(0);
+        assertThat(insert.type()).isEqualTo(ChangelogEvent.ChangeType.INSERT);
+
+        ChangelogEvent<String> delete = output.get(1);
+        assertThat(delete.type()).isEqualTo(ChangelogEvent.ChangeType.DELETE);
+        assertThat(delete.before()).isEqualTo("hello");
+        assertThat(delete.after()).isNull();
+      }
+    }
+
+    @Test
+    @DisplayName("should re-INSERT after DELETE for same key")
+    void reInsertAfterDelete() throws Exception {
+      Materializer.DeletePredicate<String> isDelete = v -> v.startsWith("DEL:");
+
+      var operator =
+          new KeyedProcessOperator<>(
+              new Materializer.MaterializeFunction<>(TTL, (a, b) -> b, isDelete));
+
+      try (var harness =
+          new KeyedOneInputStreamOperatorTestHarness<>(
+              operator, v -> v.startsWith("DEL:") ? v.substring(4) : v, Types.STRING)) {
+        harness.open();
+
+        harness.processElement(new StreamRecord<>("hello", 1L));
+        harness.processElement(new StreamRecord<>("DEL:hello", 2L));
+        harness.processElement(new StreamRecord<>("hello", 3L));
+
+        List<ChangelogEvent<String>> output = extractOutput(harness);
+
+        assertThat(output).hasSize(3);
+        assertThat(output.get(0).type()).isEqualTo(ChangelogEvent.ChangeType.INSERT);
+        assertThat(output.get(1).type()).isEqualTo(ChangelogEvent.ChangeType.DELETE);
+        assertThat(output.get(2).type()).isEqualTo(ChangelogEvent.ChangeType.INSERT);
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("Builder validation")
+  class BuilderValidation {
+
+    @Test
+    @DisplayName("should throw when keyExtractor is null")
+    void nullKeyExtractor() {
+      assertThatThrownBy(() -> Materializer.builder().ttl(TTL).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("keyExtractor");
+    }
+
+    @Test
+    @DisplayName("should throw when ttl is null")
+    void nullTtl() {
+      assertThatThrownBy(() -> Materializer.<String>builder().keyExtractor(v -> v).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("ttl");
+    }
+
+    @Test
+    @DisplayName("should use REPLACE as default merge function")
+    void defaultMergeFunction() {
+      Materializer<String> materializer =
+          Materializer.<String>builder().keyExtractor(v -> v).ttl(TTL).build();
+
+      assertThat(materializer).isNotNull();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> List<ChangelogEvent<T>> extractOutput(
+      KeyedOneInputStreamOperatorTestHarness<?, ?, ?> harness) {
+    return harness.extractOutputStreamRecords().stream()
+        .map(r -> (ChangelogEvent<T>) ((StreamRecord<?>) r).getValue())
+        .toList();
+  }
+}

--- a/src/test/java/com/streamforge/pattern/session/SessionAnalyzerTest.java
+++ b/src/test/java/com/streamforge/pattern/session/SessionAnalyzerTest.java
@@ -1,0 +1,330 @@
+package com.streamforge.pattern.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.CloseableIterator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SessionAnalyzerTest {
+
+  private static <R> List<SessionResult<R>> execute(DataStream<SessionResult<R>> stream)
+      throws Exception {
+    List<SessionResult<R>> results = new ArrayList<>();
+    try (CloseableIterator<SessionResult<R>> iter = stream.executeAndCollect("test")) {
+      while (iter.hasNext()) {
+        results.add(iter.next());
+      }
+    }
+    return results;
+  }
+
+  private static SessionAnalyzer.KeyExtractor<String> keyExtractor() {
+    return value -> value.split(":")[0];
+  }
+
+  private static SessionAnalyzer.TimestampExtractor<String> timestampExtractor() {
+    return value -> Long.parseLong(value.split(":")[1]);
+  }
+
+  private static SessionAnalyzer.Aggregator<String, Integer> countAggregator() {
+    return List::size;
+  }
+
+  private static SessionAnalyzer.Aggregator<String, String> concatAggregator() {
+    return events -> events.stream().map(e -> e.split(":")[2]).collect(Collectors.joining(","));
+  }
+
+  @Nested
+  @DisplayName("Session detection")
+  class SessionDetection {
+
+    @Test
+    @DisplayName("should detect single session within gap")
+    void singleSession() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      DataStream<String> source =
+          env.fromCollection(
+              List.of("user1:1000:click", "user1:2000:scroll", "user1:3000:click"), Types.STRING);
+
+      SessionAnalyzer<String, Integer> analyzer =
+          SessionAnalyzer.<String, Integer>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(countAggregator())
+              .gap(Duration.ofSeconds(5))
+              .build();
+
+      List<SessionResult<Integer>> results = execute(analyzer.apply(source));
+
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).key()).isEqualTo("user1");
+      assertThat(results.get(0).eventCount()).isEqualTo(3);
+      assertThat(results.get(0).result()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("should detect multiple sessions separated by gap")
+    void multipleSessions() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      DataStream<String> source =
+          env.fromCollection(
+              List.of("user1:1000:a", "user1:2000:b", "user1:10000:c", "user1:11000:d"),
+              Types.STRING);
+
+      SessionAnalyzer<String, Integer> analyzer =
+          SessionAnalyzer.<String, Integer>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(countAggregator())
+              .gap(Duration.ofSeconds(5))
+              .build();
+
+      List<SessionResult<Integer>> results = execute(analyzer.apply(source));
+      results.sort(Comparator.comparing(SessionResult::sessionStart));
+
+      assertThat(results).hasSize(2);
+      assertThat(results.get(0).eventCount()).isEqualTo(2);
+      assertThat(results.get(1).eventCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("should handle multiple keys independently")
+    void multipleKeys() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      DataStream<String> source =
+          env.fromCollection(
+              List.of("user1:1000:a", "user2:1000:b", "user1:2000:c", "user2:2000:d"),
+              Types.STRING);
+
+      SessionAnalyzer<String, Integer> analyzer =
+          SessionAnalyzer.<String, Integer>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(countAggregator())
+              .gap(Duration.ofSeconds(5))
+              .build();
+
+      List<SessionResult<Integer>> results = execute(analyzer.apply(source));
+
+      assertThat(results).hasSize(2);
+      assertThat(results).allMatch(r -> r.eventCount() == 2);
+      assertThat(results.stream().map(SessionResult::key).collect(Collectors.toSet()))
+          .containsExactlyInAnyOrder("user1", "user2");
+    }
+
+    @Test
+    @DisplayName("should set correct session start, end, and duration")
+    void sessionMetadata() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      DataStream<String> source =
+          env.fromCollection(List.of("user1:1000:a", "user1:3000:b", "user1:5000:c"), Types.STRING);
+
+      SessionAnalyzer<String, Integer> analyzer =
+          SessionAnalyzer.<String, Integer>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(countAggregator())
+              .gap(Duration.ofSeconds(10))
+              .build();
+
+      List<SessionResult<Integer>> results = execute(analyzer.apply(source));
+
+      assertThat(results).hasSize(1);
+      SessionResult<Integer> session = results.get(0);
+      assertThat(session.sessionStart().toEpochMilli()).isEqualTo(1000);
+      assertThat(session.sessionEnd().toEpochMilli()).isEqualTo(15000);
+      assertThat(session.duration()).isEqualTo(Duration.ofMillis(14000));
+    }
+  }
+
+  @Nested
+  @DisplayName("Aggregation")
+  class Aggregation {
+
+    @Test
+    @DisplayName("should apply custom aggregator")
+    void customAggregator() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      DataStream<String> source =
+          env.fromCollection(
+              List.of("user1:1000:click", "user1:2000:scroll", "user1:3000:buy"), Types.STRING);
+
+      SessionAnalyzer<String, String> analyzer =
+          SessionAnalyzer.<String, String>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(concatAggregator())
+              .gap(Duration.ofSeconds(5))
+              .build();
+
+      List<SessionResult<String>> results = execute(analyzer.apply(source));
+
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).result()).isEqualTo("click,scroll,buy");
+    }
+
+    @Test
+    @DisplayName("should handle single event session")
+    void singleEventSession() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      DataStream<String> source = env.fromCollection(List.of("user1:1000:only"), Types.STRING);
+
+      SessionAnalyzer<String, Integer> analyzer =
+          SessionAnalyzer.<String, Integer>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(countAggregator())
+              .gap(Duration.ofSeconds(5))
+              .build();
+
+      List<SessionResult<Integer>> results = execute(analyzer.apply(source));
+
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).eventCount()).isEqualTo(1);
+      assertThat(results.get(0).result()).isEqualTo(1);
+    }
+  }
+
+  @Nested
+  @DisplayName("Builder validation")
+  class BuilderValidation {
+
+    @Test
+    @DisplayName("should throw when keyExtractor is null")
+    void nullKeyExtractor() {
+      assertThatThrownBy(
+              () ->
+                  SessionAnalyzer.<String, Integer>builder()
+                      .timestampExtractor(timestampExtractor())
+                      .aggregator(countAggregator())
+                      .gap(Duration.ofSeconds(5))
+                      .build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("keyExtractor must not be null");
+    }
+
+    @Test
+    @DisplayName("should throw when timestampExtractor is null")
+    void nullTimestampExtractor() {
+      assertThatThrownBy(
+              () ->
+                  SessionAnalyzer.<String, Integer>builder()
+                      .keyExtractor(keyExtractor())
+                      .aggregator(countAggregator())
+                      .gap(Duration.ofSeconds(5))
+                      .build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("timestampExtractor must not be null");
+    }
+
+    @Test
+    @DisplayName("should throw when aggregator is null")
+    void nullAggregator() {
+      assertThatThrownBy(
+              () ->
+                  SessionAnalyzer.<String, Integer>builder()
+                      .keyExtractor(keyExtractor())
+                      .timestampExtractor(timestampExtractor())
+                      .gap(Duration.ofSeconds(5))
+                      .build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("aggregator must not be null");
+    }
+
+    @Test
+    @DisplayName("should throw when gap is null")
+    void nullGap() {
+      assertThatThrownBy(
+              () ->
+                  SessionAnalyzer.<String, Integer>builder()
+                      .keyExtractor(keyExtractor())
+                      .timestampExtractor(timestampExtractor())
+                      .aggregator(countAggregator())
+                      .build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("gap must not be null");
+    }
+
+    @Test
+    @DisplayName("should use default outOfOrderness when not set")
+    void defaultOutOfOrderness() {
+      SessionAnalyzer<String, Integer> analyzer =
+          SessionAnalyzer.<String, Integer>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(countAggregator())
+              .gap(Duration.ofSeconds(5))
+              .build();
+      assertThat(analyzer).isNotNull();
+    }
+
+    @Test
+    @DisplayName("should build with allowedLateness")
+    void withAllowedLateness() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      DataStream<String> source =
+          env.fromCollection(List.of("user1:1000:a", "user1:2000:b"), Types.STRING);
+
+      SessionAnalyzer<String, Integer> analyzer =
+          SessionAnalyzer.<String, Integer>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(countAggregator())
+              .gap(Duration.ofSeconds(5))
+              .allowedLateness(Duration.ofSeconds(10))
+              .build();
+
+      List<SessionResult<Integer>> results = execute(analyzer.apply(source));
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).eventCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("should build with outOfOrderness")
+    void withOutOfOrderness() throws Exception {
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+
+      DataStream<String> source =
+          env.fromCollection(List.of("user1:3000:a", "user1:1000:b", "user1:2000:c"), Types.STRING);
+
+      SessionAnalyzer<String, Integer> analyzer =
+          SessionAnalyzer.<String, Integer>builder()
+              .keyExtractor(keyExtractor())
+              .timestampExtractor(timestampExtractor())
+              .aggregator(countAggregator())
+              .gap(Duration.ofSeconds(5))
+              .outOfOrderness(Duration.ofSeconds(5))
+              .build();
+
+      List<SessionResult<Integer>> results = execute(analyzer.apply(source));
+      assertThat(results).hasSize(1);
+      assertThat(results.get(0).eventCount()).isEqualTo(3);
+    }
+  }
+}


### PR DESCRIPTION
 Summary  
                                                                                                                                                                                                                                   
  - Add SessionAnalyzer: gap-based session windowing with configurable key extraction, timestamp extraction, and custom aggregation. UserSessionAnalysisJob composes Kafka source → SessionAnalyzer → MongoDB sink                 
  - Add Materializer: TTL-backed keyed state materialization that generates typed changelog events (INSERT/UPDATE/DELETE). UserStateMaterializeJob composes Kafka source → Materializer → Kafka compacted sink
  - Add Compactor: (commit included)                                                                                                                                                                                               
  - Add MultiCdcSourceBuilder: opens N parallel MongoChangeStreamSource instances with hash-mod filtering, unions into single DataStream. MongoToKafkaJob updated to use it via CDC_PARALLELISM config

  Test plan

  - [x] SessionAnalyzerTest (6 tests)
  - [x] MaterializerTest (5 tests)
  - [x] UserSessionAnalysisJobTest (3 tests)
  - [x] MultiCdcSourceTest (5 tests)
  - [x] KafkaSinkBuilderTest (4 tests)
  - [x] StreamEnvelopParserTest
  - [x] All existing tests pass
